### PR TITLE
Builds for multiple Squeak versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ smalltalk: "Squeak64-${SQUEAK_VERSION}"
 before_script:
 - chmod +x travis_fold
 - |
-  # DEBUG_FIGURES allows PDF builds despite of missing figures
+  # DEBUG_FIGURES allows PDF builds despite missing figures
   export DEBUG_FIGURES=true && [ "$TRAVIS_BRANCH" = "master" ] && export DEBUG_FIGURES=false ; :
 - set -o pipefail
 
@@ -22,7 +22,6 @@ script:
 - mv SBE.pdf "SBE_${SQUEAK_VERSION}.pdf"
 
 after_script:
-- echo $TRAVIS_PULL_REQUEST # DEBUG!!!
 - | # Upload PDF file to Google Drive
   if [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && [ "$TRAVIS_PULL_REQUEST" = false ]
   then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ script:
 
 after_script:
 - | # Upload PDF file to Google Drive
-  [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+  if [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && [ $TRAVIS_PULL_REQUEST=false ]
+  then
+    bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+  fi
 
 deploy:
   - # Create GitHub release

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,16 @@ script:
 
 deploy:
   - # Upload PDF file to Google Drive
-    script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
-  - # Create GitHub release
+    provider: script
     on:
       all_branches: true
-  - provider: releases
-    api_key:
-      secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=
-    file: "${TRAVIS_BUILD_DIR}/SBE_{SQUEAK_VERSION}.pdf"
+    cleanup: false
+    script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+  - # Create GitHub release
+    provider: releases
     on:
       branch: master
+    cleanup: false
+    file: "${TRAVIS_BUILD_DIR}/SBE_{SQUEAK_VERSION}.pdf"
+    api_key:
+      secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ smalltalk: "Squeak64-${SQUEAK_VERSION}"
 before_script:
 - chmod +x travis_fold
 - |
+  # DEBUG_FIGURES allows PDF builds despite of missing figures
   export DEBUG_FIGURES=true && [ "$TRAVIS_BRANCH" = "master" ] && export DEBUG_FIGURES=false ; :
 - set -o pipefail
 
@@ -21,8 +22,9 @@ script:
 - mv SBE.pdf "SBE_${SQUEAK_VERSION}.pdf"
 
 deploy:
-  - provider: script
+  - # Upload PDF file to Google Drive
     script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+  - # Create GitHub release
     on:
       all_branches: true
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: smalltalk
-sudo: true
 services:
 - docker
     
@@ -24,11 +23,9 @@ script:
 deploy:
   - provider: script
     script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
-    skip_cleanup: true
   - provider: releases
     api_key:
       secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=
     file: "${TRAVIS_BUILD_DIR}/SBE_{SQUEAK_VERSION}.pdf"
-    skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - SQUEAK_VERSION=Trunk
   - SQUEAK_VERSION=5.3
 
-smalltalk: "Squeak-${SQUEAK_VERSION}"
+smalltalk: "Squeak64-${SQUEAK_VERSION}"
 
 before_script:
 - chmod +x travis_fold

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 after_script:
 - echo $TRAVIS_PULL_REQUEST # DEBUG!!!
 - | # Upload PDF file to Google Drive
-  if [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && [ $TRAVIS_PULL_REQUEST=false ]
+  if [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && [ "$TRAVIS_PULL_REQUEST" = false ]
   then
     bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
 deploy:
   - provider: script
     script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+    on:
+      all_branches: true
   - provider: releases
     api_key:
       secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,11 @@ script:
 - "make | ./travis_fold Compiling PDF ..."
 - mv SBE.pdf "SBE_${SQUEAK_VERSION}.pdf"
 
+after_script:
+- | # Upload PDF file to Google Drive
+  [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+
 deploy:
-  - # Upload PDF file to Google Drive
-    provider: script
-    on:
-      all_branches: true
-    cleanup: false
-    script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
   - # Create GitHub release
     provider: releases
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 - mv SBE.pdf "SBE_${SQUEAK_VERSION}.pdf"
 
 after_script:
+- echo $TRAVIS_PULL_REQUEST # DEBUG!!!
 - | # Upload PDF file to Google Drive
   if [ -f "SBE_${SQUEAK_VERSION}.pdf" ] && [ $TRAVIS_PULL_REQUEST=false ]
   then
@@ -37,3 +38,7 @@ deploy:
     file: "${TRAVIS_BUILD_DIR}/SBE_{SQUEAK_VERSION}.pdf"
     api_key:
       secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=
+
+notifications:
+  email:
+    if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ language: smalltalk
 sudo: true
 services:
 - docker
-smalltalk:
-- Squeak-Trunk
+    
+env:
+  jobs:
+  - SQUEAK_VERSION=Trunk
+  - SQUEAK_VERSION=5.3
+
+smalltalk: "Squeak-${SQUEAK_VERSION}"
 
 before_script:
 - chmod +x travis_fold
@@ -14,13 +19,16 @@ before_script:
 script:
 - smalltalkci .smalltalk.ston
 - "make | ./travis_fold Compiling PDF ..."
-- "[ -f SBE.pdf ] && bash -e deploy-debug.sh SBE.pdf ; :"
+- mv SBE.pdf "SBE_${SQUEAK_VERSION}.pdf"
 
 deploy:
-  provider: releases
-  api_key:
-    secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=
-  file: ${TRAVIS_BUILD_DIR}/SBE.pdf
-  skip_cleanup: true
-  on:
-    branch: master
+  - provider: script
+    script: bash -e deploy-debug.sh "SBE_${SQUEAK_VERSION}.pdf"
+    skip_cleanup: true
+  - provider: releases
+    api_key:
+      secure: KcvH99B3Ab567MgJxsMOfvvxs0Q7qQw3WHlmyESkF5/B+wOBX3XJkFKF+3HeRejqUiZCIjsHEfgamufPGp/a9vdrEgOnLsjnlrsheje9/hHIC+fmQp0g6BpeIfF/eHlyE2W4Lx+mwQASzYjEvGIERlnrXUAWG+0k1BbB31JhF1kznjFe1gEwlfltIqxL7Bxm6dFyucn8PV1N8liq2B9iKsUapXBC7Qfen2L/tTuVljhdWb1GsIX8FzeIFXdJbmlBjaiUNb8uCFYyWqaqcq2+N+nmUos/flqaQZor0bz1WtrKvwdpoenWrLmh7FDjSRdpTCXWaaH62Rw2p+bcWxdjz9sGEu/NAEPvdpFirNRPX2k8bhA7QbdqrLPrznu9vs6Ygo6pBeapUSIU6KwK5LazoWn61HIh8Ib6s3sZeu7w/N3u7jGMhhbGNRGcISCHKTYw0oYIdT0+F6nRUpV0ov2h/u9qslVPtksxbdjFeuy/BAKmTiCseiaVBol5TWG++SY7Uo5sQT6/2jpjAV2bOUV35VU4/zObftCo21WzZXzWV+Q9XruOPBs0XRRTFJxrKm35ECS/5FputYtD7EJ3+xtPAEHp/JZxHTydN20XDxM0iDS19tk7t+L6bYpWDjuul2GLJOjUp5kVfzSt0cEjuNX1E6YH7SmNJFvF5snwlYrHESs=
+    file: "${TRAVIS_BUILD_DIR}/SBE_{SQUEAK_VERSION}.pdf"
+    skip_cleanup: true
+    on:
+      branch: master

--- a/Environment/Environment.tex
+++ b/Environment/Environment.tex
@@ -807,7 +807,7 @@ SBEScreenshotRecorder writeTo: './figures/MCaddToPackage.png' building: [:helper
 	| repositoryMatch repositoryList |
 	thisContext wrap: [:block | helper mcIgnoreAllModificationsDuring: block].
 	MCWorkingCopyBrowser open.
-	repositoryMatch := MCRepository trunk description.
+	repositoryMatch := MCRepository packageCache description.
 	repositoryList := helper listMorphIncludingMatch: repositoryMatch in: helper foregroundWindow.
 	helper select: repositoryList at: repositoryMatch.
 	helper keyStroke: repositoryList key: Character escape.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifndef TRAVIS
 	ifdef NO_WSL
 		PREFIX = cmd.exe /c
 	else
-		PREFIX = ""
+		PREFIX = 
 	endif
 	PDFLATEX = ${PREFIX} pdflatex -file-line-error -interaction=nonstopmode
 	BIBTEX = ${PREFIX} bibtex
@@ -24,7 +24,7 @@ endif
 
 BOOK=SBE
 ETC=SBE-etc
-TEXINPUT=$(shell TEXINPUT='\\\\input{${BOOK}}' && [ "$$DEBUG_FIGURES" = true ] && TEXINPUT='\\\\AtBeginDocument{\\\\include{robustize-figures}}'"$$TEXINPUT" ;echo $$TEXINPUT)
+TEXINPUT=$(shell echo "$$([ "$$DEBUG_FIGURES" = true ] && echo '\\\\AtBeginDocument{\\\\include{robustize-figures}}')$$([ -z "$$SQUEAK_VERSION" ] || echo '\\\\newcommand{\\\\SQUEAKVERSION}{${SQUEAK_VERSION}}')\\\\input{${BOOK}}")
 
 # --------------------------------------------------------------------------------
 all : book
@@ -35,10 +35,10 @@ all : book
 book: clean listings book-pages
 
 book-pages :
-	time ${PDFLATEX} ${TEXINPUT}
+	time ${PDFLATEX} '${TEXINPUT}'
 	time ${BIBTEX} ${BOOK}
-	time ${PDFLATEX} ${TEXINPUT}
-	time ${PDFLATEX} ${TEXINPUT} | tee warnings.txt
+	time ${PDFLATEX} '${TEXINPUT}'
+	time ${PDFLATEX} '${TEXINPUT}' | tee warnings.txt
 	# Filter out blank lines and bogus warnings
 	perl -pi \
 		-e '$$/ = "";' \

--- a/README.markdown
+++ b/README.markdown
@@ -81,17 +81,18 @@ to verify that you have added all the dependent files (e.g., figures).
 
 ## Build process
 
-The PDF of the book is built automatically via TravisCI on each commit, which includes generation of all screenshots, that are codified, for the latest Squeak version. The usual workflow how to codify a screenshot is documented [here](https://github.com/codeZeilen/SqueakByExample-english/issues/21#issue-516598115). If the build process completed, you can watch the results [here](https://drive.google.com/drive/folders/1tNIvN-9Vx8djNZYfSYuqhjheb-EgJuTc).
+The PDF of the book is built via Travis CI on each commit, which includes the execution of SBEtests and the generation of screenshots that are described by a figure script. Two PDFs are created, one for the latest Squeak release and one for the current Trunk version.
+
+The usual workflow to codify a screenshot is documented [here](https://github.com/codeZeilen/SqueakByExample-english/issues/21#issue-516598115). If the build process completed, you can watch the results [here](https://drive.google.com/drive/folders/1tNIvN-9Vx8djNZYfSYuqhjheb-EgJuTc).
 To build the PDF manually, do the following:
 ### I. Installation
 1. Get a support Squeak image (any release since 5.3 or the latest Trunk image)
-2. Install [Squot](https://github.com/hpi-swa/Squot)
-3. Open the Git Browser and clone this repository
-4. Make sure to set the resource directory to the path of your working copy:
+2. Open the Git Browser and clone this repository
+3. Make sure to set the resource directory to the path of your working copy:
  ```smalltalk
 SBEFigureBuilder resourceDirectory: FileDirectory default asFSReference / 'path' / 'to' / 'workingCopy'.
  ```
-5. Install any unix system.
+4. Install any Linux distribution.
 ### II. Building
 1. Do it:
  ```smalltalk

--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,7 @@ to verify that you have added all the dependent files (e.g., figures).
 The PDF of the book is built automatically via TravisCI on each commit, which includes generation of all screenshots, that are codified, for the latest Squeak version. The usual workflow how to codify a screenshot is documented [here](https://github.com/codeZeilen/SqueakByExample-english/issues/21#issue-516598115). If the build process completed, you can watch the results [here](https://drive.google.com/drive/folders/1tNIvN-9Vx8djNZYfSYuqhjheb-EgJuTc).
 To build the PDF manually, do the following:
 ### I. Installation
-1. Get the latest Trunk image for Squeak
+1. Get a support Squeak image (any release since 5.3 or the latest Trunk image)
 2. Install [Squot](https://github.com/hpi-swa/Squot)
 3. Open the Git Browser and clone this repository
 4. Make sure to set the resource directory to the path of your working copy:

--- a/SBE.tex
+++ b/SBE.tex
@@ -62,7 +62,10 @@
 % (to be updated at the end)
 \title{\Huge\bf Squeak by Example}
 \isodate
-\date{\emph{Version of \today}}
+\date{\emph{Version of \today {\ifdefined\SQUEAKVERSION
+	\space{}for Squeak \SQUEAKVERSION% 
+	\else\fi}%
+}}
 \maketitle
 %=================================================================
 %:Copyright notice

--- a/deploy-debug.sh
+++ b/deploy-debug.sh
@@ -33,7 +33,7 @@ if [ ! -f $GDRIVE ]; then install_gdrive; fi
 
 FIXED_BRANCH=$(echo $TRAVIS_BRANCH | sed 's/\//-/g')
 FIXED_REPO=$(echo $TRAVIS_REPO_SLUG | sed 's/\//-/g')
-FILE_NAME="SBE-$FIXED_REPO-$FIXED_BRANCH.pdf"
+FILE_NAME="${SOURCE%.*}-$FIXED_REPO-$FIXED_BRANCH.pdf"
 GDRIVE_FILE=$(find_file $FILE_NAME)
 if [[ $GDRIVE_FILE ]]; then
 	echo "Uploading new version of ${FILE_NAME} ..."


### PR DESCRIPTION
This PR changes to Travis CI build configuration so that on every build, two jobs are scheduled one of which creates an `SBE_trunk.pdf` and the other one `SBE_5.3` output file. See https://github.com/codeZeilen/SqueakByExample-english/issues/31#issuecomment-699002752.