### PR TITLE
Adjust screenshot appearance according to #74

### DIFF
--- a/SmalltalkSources/SBE-Extract.package/SBEWorldHelper.class/instance/useScreenshotPreferencesDuring..st
+++ b/SmalltalkSources/SBE-Extract.package/SBEWorldHelper.class/instance/useScreenshotPreferencesDuring..st
@@ -3,8 +3,17 @@ useScreenshotPreferencesDuring: aBlock
 
 	^ Preferences
 		setPreferences: ({
+			"Necessary for proper simulation"
 			#(UIManager >> #openToolsAttachedToMouseCursor) -> false.
+			
+			"Appearance"
+			#menuAppearance3d -> false.
+			#(DialogWindow >> roundedDialogCorners) -> true.
+			#(MenuMorph >> roundedMenuCorners) -> true.
 			#(Model >> #useColorfulWindows) -> true.
+			#(PluggableButtonMorph >> roundedButtonCorners) -> true.
+			#(ScrollBar >> roundedScrollBarLook) -> true.
+			#(SystemWindow >> roundedWindowCorners) -> true.
 			#(Workspace >> #shouldStyle) -> true }
 				collect: [:setting | setting key join asSymbol -> setting value])
 		during: aBlock

--- a/SmalltalkSources/SBE-Extract.package/SBEWorldHelper.class/methodProperties.json
+++ b/SmalltalkSources/SBE-Extract.package/SBEWorldHelper.class/methodProperties.json
@@ -96,7 +96,7 @@
 		"touchMethod:" : "ct 12/6/2019 16:45",
 		"touchMethods:" : "ct 12/6/2019 16:43",
 		"type:into:" : "ct 10/21/2019 17:58",
-		"useScreenshotPreferencesDuring:" : "ct 1/18/2020 02:24",
+		"useScreenshotPreferencesDuring:" : "ct 11/6/2020 17:20",
 		"useScreenshotSettingsDuring:" : "ct 1/10/2020 16:07",
 		"useTemporaryChangeSetDuring:" : "ct 9/19/2020 17:56",
 		"useWorldAndHandDuring:" : "ct 10/14/2020 14:49",


### PR DESCRIPTION
See https://github.com/hpi-swa-lab/SqueakByExample-english/issues/74#issuecomment-723046245 for more information.

Before:
![image](https://user-images.githubusercontent.com/38782922/98389762-cc306f00-2054-11eb-998f-6709940c5843.png)

After:
![image](https://user-images.githubusercontent.com/38782922/98389776-d0f52300-2054-11eb-9359-100ea0115999.png)
