### PR TITLE
Fix TranslucentColor selectors for Squeak 6.0

### DIFF
--- a/.squot
+++ b/.squot
@@ -1,11 +1,11 @@
 OrderedDictionary {
-	'SmalltalkSources/SBE-Environment.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Morphic.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-QuickTour.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Quinto.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Streams.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Testing.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Extract.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/BaselineOfSBE.package' : #SquotCypressCodeSerializer,
-	'SmalltalkSources/SBE-Monticello.package' : #SquotCypressCodeSerializer
+	'SmalltalkSources\/SBE-Environment.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Morphic.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-QuickTour.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Quinto.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Streams.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Testing.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Extract.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/BaselineOfSBE.package' : #SquotCypressCodeSerializer,
+	'SmalltalkSources\/SBE-Monticello.package' : #SquotCypressCodeSerializer
 }

--- a/Metaclasses/Metaclasses.tex
+++ b/Metaclasses/Metaclasses.tex
@@ -231,7 +231,7 @@ TranslucentColor subclasses         --> #()
 TranslucentColor allSuperclasses  --> an OrderedCollection(Color Object ProtoObject)
 TranslucentColor instVarNames     --> #('alpha')
 TranslucentColor allInstVarNames --> #('rgb' 'cachedDepth' 'cachedBitPattern' 'alpha')
-TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: \SqVersionSwitch{6.0}{#printOn:}{} #privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
+TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: !\SqVersionSwitch{6.0}{#printOn:}{}! #privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
 \end{code}
 \cmindex{Class}{subclasses}
 \cmindex{Behavior}{allSuperclasses}

--- a/Metaclasses/Metaclasses.tex
+++ b/Metaclasses/Metaclasses.tex
@@ -231,7 +231,7 @@ TranslucentColor subclasses         --> #()
 TranslucentColor allSuperclasses  --> an OrderedCollection(Color Object ProtoObject)
 TranslucentColor instVarNames     --> #('alpha')
 TranslucentColor allInstVarNames --> #('rgb' 'cachedDepth' 'cachedBitPattern' 'alpha')
-TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: #privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
+TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: \SqVersionSwitch{6.0}{#printOn:}{} #privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
 \end{code}
 \cmindex{Class}{subclasses}
 \cmindex{Behavior}{allSuperclasses}

--- a/Metaclasses/Metaclasses.tex
+++ b/Metaclasses/Metaclasses.tex
@@ -231,7 +231,7 @@ TranslucentColor subclasses         --> #()
 TranslucentColor allSuperclasses  --> an OrderedCollection(Color Object ProtoObject)
 TranslucentColor instVarNames     --> #('alpha')
 TranslucentColor allInstVarNames --> #('rgb' 'cachedDepth' 'cachedBitPattern' 'alpha')
-TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: !\SqVersionSwitch{6.0}{#printOn:}{}! #privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
+TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: !\SqVersionSwitch{6.0 }{#printOn:}{}!#privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
 \end{code}
 \cmindex{Class}{subclasses}
 \cmindex{Behavior}{allSuperclasses}

--- a/Metaclasses/Metaclasses.tex
+++ b/Metaclasses/Metaclasses.tex
@@ -231,7 +231,7 @@ TranslucentColor subclasses         --> #()
 TranslucentColor allSuperclasses  --> an OrderedCollection(Color Object ProtoObject)
 TranslucentColor instVarNames     --> #('alpha')
 TranslucentColor allInstVarNames --> #('rgb' 'cachedDepth' 'cachedBitPattern' 'alpha')
-TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: !\SqVersionSwitch{6.0 }{#printOn:}{}!#privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
+TranslucentColor selectors sorted --> #(#addName: #alpha #alpha: #asHTMLColor #asNontranslucentColor #balancedPatternForDepth: #bitPatternForDepth: #convertToCurrentVersion:refStream: #hash #isOpaque #isTranslucent #isTranslucentColor #isTransparent #name #pixelValueForDepth: #pixelWordForDepth: !\SqVersionSwitch{6.0}{\#printOn: }{}!#privateAlpha #scaledPixelValue32 #setRgb:alpha: #storeArrayValuesOn: #storeOn:)
 \end{code}
 \cmindex{Class}{subclasses}
 \cmindex{Behavior}{allSuperclasses}

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
@@ -13,7 +13,6 @@ sourceLines: lines
 				into: [:result :escape |
 					result copyWithRegex: escape key matchesReplacedWith: escape value])
 			translatingMatchesUsing: [:match |
-				self halt.
 				self systemVersionString >= (matcher subexpression: 2)
 					ifTrue: [matcher subexpression: 3]
 					ifFalse: [matcher subexpression: 5]]].

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
@@ -5,7 +5,7 @@ sourceLines: lines
 	| matcher |
 	self flag: #NB. "This is not fully compatible with escaping inside the source nor with patterns spanning over multiple lines, implement this when you really need it ..."
 	
-	matcher := '!\s*\\SqVersionSwitch\{([\w.]+)\}\{((\\[{}]|[^{}])+)\}\{((\\[{}]|[^{}])+)\}\s*!' asRegex.
+	matcher := '!\s*\\SqVersionSwitch\{([\w.]+)\}\{((\\[{}]|[^{}])*)\}\{((\\[{}]|[^{}])*)\}\s*!' asRegex.
 	sourceLines := lines collect: [:line |
 		matcher
 			copy: (self escapeSequences
@@ -13,6 +13,7 @@ sourceLines: lines
 				into: [:result :escape |
 					result copyWithRegex: escape key matchesReplacedWith: escape value])
 			translatingMatchesUsing: [:match |
+				self halt.
 				self systemVersionString >= (matcher subexpression: 2)
 					ifTrue: [matcher subexpression: 3]
 					ifFalse: [matcher subexpression: 5]]].

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/sourceLines..st
@@ -13,8 +13,8 @@ sourceLines: lines
 				into: [:result :escape |
 					result copyWithRegex: escape key matchesReplacedWith: escape value])
 			translatingMatchesUsing: [:match |
-				self systemVersionString >= (matcher subexpression: 2)
+				self unescapeLatex: (self systemVersionString >= (matcher subexpression: 2)
 					ifTrue: [matcher subexpression: 3]
-					ifFalse: [matcher subexpression: 5]]].
+					ifFalse: [matcher subexpression: 5])]].
 	
 	self chapter generateTestMethod: self testSource.

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/unescapeLatex..st
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/instance/unescapeLatex..st
@@ -1,0 +1,9 @@
+private
+unescapeLatex: latexString
+	"Custom latex commands are not supported here!"
+
+	| matcher |
+	matcher := '\\([\\#\{\}\[\]])' asRegex.
+	^ matcher
+		copy: latexString
+		translatingMatchesUsing: [:match | matcher subexpression: 2]

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
@@ -9,9 +9,10 @@
 		"escapeSequences" : "ct 9/23/2020 14:31",
 		"removeTrailingComments:" : "on 8/15/2007 11:11",
 		"sourceLines" : "on 6/12/2007 14:06",
-		"sourceLines:" : "ct 2/15/2021 15:38",
+		"sourceLines:" : "ct 2/15/2021 15:55",
 		"start" : "on 6/12/2007 12:51",
 		"start:" : "on 6/12/2007 12:51",
 		"systemVersionString" : "ct 9/29/2020 20:49",
 		"testName" : "on 6/12/2007 14:37",
-		"testSource" : "ct 9/22/2020 21:03" } }
+		"testSource" : "ct 9/22/2020 21:03",
+		"unescapeLatex:" : "ct 2/15/2021 16:00" } }

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
@@ -9,7 +9,7 @@
 		"escapeSequences" : "ct 9/23/2020 14:31",
 		"removeTrailingComments:" : "on 8/15/2007 11:11",
 		"sourceLines" : "on 6/12/2007 14:06",
-		"sourceLines:" : "ct 10/13/2020 21:13",
+		"sourceLines:" : "ct 2/15/2021 15:30",
 		"start" : "on 6/12/2007 12:51",
 		"start:" : "on 6/12/2007 12:51",
 		"systemVersionString" : "ct 9/29/2020 20:49",

--- a/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
+++ b/SmalltalkSources/SBE-Testing.package/SBEtest.class/methodProperties.json
@@ -9,7 +9,7 @@
 		"escapeSequences" : "ct 9/23/2020 14:31",
 		"removeTrailingComments:" : "on 8/15/2007 11:11",
 		"sourceLines" : "on 6/12/2007 14:06",
-		"sourceLines:" : "ct 2/15/2021 15:30",
+		"sourceLines:" : "ct 2/15/2021 15:38",
 		"start" : "on 6/12/2007 12:51",
 		"start:" : "on 6/12/2007 12:51",
 		"systemVersionString" : "ct 9/29/2020 20:49",

--- a/common.tex
+++ b/common.tex
@@ -337,6 +337,9 @@
 \definecolor{source}{gray}{0.95}
 \usepackage{listings}
 \usepackage{textcomp} % For upquote
+\makeatletter
+\lst@AddToHook{InitVars}{\finalhyphendemerits=0\relax\doublehyphendemerits=0\relax}
+\makeatother
 \lstdefinelanguage{Smalltalk}{
   morekeywords={self,super,true,false,nil,thisContext},
   morestring=[d]',

--- a/common.tex
+++ b/common.tex
@@ -337,6 +337,7 @@
 \definecolor{source}{gray}{0.95}
 \usepackage{listings}
 \usepackage{textcomp} % For upquote
+% Prevent line breaks after escape sections within a listing, see: https://tex.stackexchange.com/a/583537/221054
 \makeatletter
 \lst@AddToHook{InitVars}{\finalhyphendemerits=0\relax\doublehyphendemerits=0\relax}
 \makeatother


### PR DESCRIPTION
Complements Graphics-nice.444. Also includes a fix in the SBEtest parsing logic of `\SqVersionSwitch` which did not accept escape sequences or empty arguments before.