### PR TITLE
Fix & replace example for `#printOn:` specialization

### DIFF
--- a/BasicClasses/BasicClasses.tex
+++ b/BasicClasses/BasicClasses.tex
@@ -101,7 +101,7 @@ TTCFont>>>printOn: aStream
 \end{method}
 
 \begin{code}{@TEST}
-TTCFont allInstances anyOne printString --> !\SqVersionSwitch{6.0}{'a TTCFont(BitstreamVeraSans Bold 6pt 96ppi 8.0px)'}{'TTCFont(BitstreamVeraSans 6 Bold)'}! 
+TTCFont allInstances anyOne printString --> !\SqVersionSwitch{6.0}{'a TTCFont(BitstreamVeraSans Bold 36pt 96ppi 48px)'}{'TTCFont(BitstreamVeraSans 6 Bold)'}! 
 \end{code}
 
 Note that the message \ct{printOn:} is not the same as \mthind{Object}{storeOn:}.

--- a/BasicClasses/BasicClasses.tex
+++ b/BasicClasses/BasicClasses.tex
@@ -86,39 +86,21 @@ For example, the class \clsind{Browser} does not redefine the method \ct{printOn
 Browser new printString --> 'a Browser'
 \end{code}
 
-In contrast, the class \ct{TTCFont} shows an example of \mthind{TTCFont}{printOn:} specialization.
-It prints the name of the class followed by the family name, the size, and some other properties of the font as shown by the code below which prints an instance of the class.
+In contrast, the class \ct{PackageInfo} shows an example of \mthind{PackageInfo}{printOn:} specialization.
+In addition to the usual name of the class, it prints the name of the package as shown by the code below which prints an instance of the class.
 
-\SqVersionSwitch{6.0}{
 \needlines{7}
 \begin{method}[zork]{printOn: redefinition.}
-TTCFont>>>printOn: aStream
+PackagInfo>>>printOn: aStream
 	super printOn: aStream.
-	
 	aStream
 		nextPut: $(;
-		nextPutAll: self familyName;
-		space; nextPutAll: self subfamilyName;
-		space; print: self pointSize; nextPutAll: 'pt';
-		space; print: self pixelsPerInch; nextPutAll: 'ppi';
-		space; print: self height; nextPutAll: 'px';
+		nextPutAll: self packageName;
 		nextPut: $)
 \end{method}
-}{
-\needlines{7}
-\begin{method}[zork]{printOn: redefinition.}
-TTCFont>>>printOn: aStream
-
-    aStream nextPutAll: 'TTCFont(';
-        nextPutAll: self familyName; space;
-        print: self pointSize; space;
-        nextPutAll: self subfamilyName;
-        nextPut: $).
-\end{method}
-}
 
 \begin{code}{@TEST}
-(TTCFont family: #BitstreamVeraSans size: 12) printString --> !\SqVersionSwitch{6.0}{'a TTCFont(BitstreamVeraSans Roman 12pt 96ppi 16px)'}{'TTCFont(BitstreamVeraSans 12 Roman)'}! 
+Object packageInfo printString --> 'a PackageInfo(Kernel)'
 \end{code}
 
 Note that the message \ct{printOn:} is not the same as \mthind{Object}{storeOn:}.

--- a/BasicClasses/BasicClasses.tex
+++ b/BasicClasses/BasicClasses.tex
@@ -87,21 +87,38 @@ Browser new printString --> 'a Browser'
 \end{code}
 
 In contrast, the class \ct{TTCFont} shows an example of \mthind{TTCFont}{printOn:} specialization.
-It prints the name of the class followed by the family name, the size, and the subfamily name of the font as shown by the code below which prints an instance of the class.
+It prints the name of the class followed by the family name, the size, and some other properties of the font as shown by the code below which prints an instance of the class.
 
+\SqVersionSwitch{6.0}{
+\needlines{7}
+\begin{method}[zork]{printOn: redefinition.}
+TTCFont>>>printOn: aStream
+	super printOn: aStream.
+	
+	aStream
+		nextPut: $(;
+		nextPutAll: self familyName;
+		space; nextPutAll: self subfamilyName;
+		space; print: self pointSize; nextPutAll: 'pt';
+		space; print: self pixelsPerInch; nextPutAll: 'ppi';
+		space; print: self height; nextPutAll: 'px';
+		nextPut: $)
+\end{method}
+}{
 \needlines{7}
 \begin{method}[zork]{printOn: redefinition.}
 TTCFont>>>printOn: aStream
 
     aStream nextPutAll: 'TTCFont(';
-		nextPutAll: self familyName; space;
-		print: self pointSize; space;
-		nextPutAll: self subfamilyName;
-		nextPut: $).
+        nextPutAll: self familyName; space;
+        print: self pointSize; space;
+        nextPutAll: self subfamilyName;
+        nextPut: $).
 \end{method}
+}
 
 \begin{code}{@TEST}
-TTCFont allInstances anyOne printString --> !\SqVersionSwitch{6.0}{'a TTCFont(BitstreamVeraSans Bold 36pt 96ppi 48px)'}{'TTCFont(BitstreamVeraSans 6 Bold)'}! 
+(TTCFont family: #BitstreamVeraSans size: 12) printString --> !\SqVersionSwitch{6.0}{'a TTCFont(BitstreamVeraSans Roman 12pt 96ppi 16px)'}{'TTCFont(BitstreamVeraSans 12 Roman)'}! 
 \end{code}
 
 Note that the message \ct{printOn:} is not the same as \mthind{Object}{storeOn:}.


### PR DESCRIPTION
`PackageInfo` is a simpler example and more idiomatic by sending super. Also, it has not been changed recently and does not require any `\SqVersionSwitch` which unfortunately seems to be incompatible with `\begin{method}`.