### PR TITLE
Fix figure Environment/fixOffByOne by excluding slow string test `#testPercentEncodingJa`

### DIFF
--- a/Environment/Environment.tex
+++ b/Environment/Environment.tex
@@ -1344,7 +1344,8 @@ SBEScreenshotRecorder writeTo: './figures/fixOffByOne.png' building: [:helper |
 			String >> #suffix.
 			StringTest >> #testSuffixFound.
 			StringTest >> #testSuffixNotFound.
-			StringTest >> #testShout. }
+			StringTest >> #testShout.
+			StringTest >> #testPercentEncodingJa. }
 		after: block].
 	String compile: 'suffix
 
@@ -1360,6 +1361,7 @@ self assert: ''txt'' equals: ''readme.txt'' suffix'
 .
 	StringTest compile: 'testShout'. "To prevent a failure from this test"
 	StringTest removeSelector: #testSuffixNotFound.
+	StringTest removeSelector: #testPercentEncodingJa. "very slow"
 	testRunner := TestRunner newForSuite: StringTest suite.
 	testRunner runAll.
 	ToolBuilder open: testRunner.


### PR DESCRIPTION
See also: https://lists.squeakfoundation.org/pipermail/squeak-dev/2022-March/219578.html