### PR TITLE
fix: update paragraph to fit preceding screenshot and do-this-action

### DIFF
--- a/QuickTour/QuickTour.tex
+++ b/QuickTour/QuickTour.tex
@@ -461,8 +461,8 @@ SBEScreenshotRecorder writeTo: './figures/Doit.png' frame: [:morphsRect | morphs
 \end{figure}
 
 You have just evaluated your first \st expression!
-You just sent the message \ct{show: 'hello world'} to the \ct{Transcript} object, followed by the message \ct{cr} (carriage return).
-The \ct{Transcript} then decided what to do with this message, that is, it looked up its \emph{methods} for handling \ct{show:} and \ct{cr} messages and reacted appropriately.
+You just sent the message \ct{showln: 'hello world'} to the \ct{Transcript} object.
+The \ct{Transcript} then decided what to do with this message, that is, it looked up its \emph{methods} for handling \ct{showln:} messages and reacted appropriately.
 
 If you talk to Smalltalkers for a while, you will quickly notice that they generally do not use expressions like ``call an operation'' or ``invoke a method'', but instead they will say ``send a message''.
 This reflects the idea that objects are responsible for their own actions.


### PR DESCRIPTION
In the "Type the following text into the workspace:" the reader should type "Transcript showln: 'hello world'." into their workspace and execute "do it (d)" afterwards. This corresponds to Figure 1.10. Alas the following paragraph tells about sending "show: 'hello world'" and "cr" to the Transcript object which was the case in the 5.3 version of SBE.